### PR TITLE
Deleting a decision now cascades to machine decisions

### DIFF
--- a/database/migrations/2025_10_09_095401_add_cascade_to_machine_decisions_table.php
+++ b/database/migrations/2025_10_09_095401_add_cascade_to_machine_decisions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('machine_decisions', function (Blueprint $table) {
+            $table->dropForeign(['decision_id']);
+            $table->foreign('decision_id')
+                ->references('id')->on('decisions')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('machine_decisions', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
This is needed for future updates, for example when deleting/resetting a period.